### PR TITLE
Improve bill_type parameter descriptions for LLM clients

### DIFF
--- a/src/congress_mcp/tools/bills.py
+++ b/src/congress_mcp/tools/bills.py
@@ -73,7 +73,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         bill_type: Annotated[
             BillType,
             Field(
-                description="Bill type: hr (House Bill), s (Senate Bill), hjres (House Joint Resolution), sjres (Senate Joint Resolution), hconres (House Concurrent Resolution), sconres (Senate Concurrent Resolution), hres (House Simple Resolution), sres (Senate Simple Resolution)"
+                description="REQUIRED bill type string. Must be one of: hr (House Bill), s (Senate Bill), hjres (House Joint Resolution), sjres (Senate Joint Resolution), hconres (House Concurrent Resolution), sconres (Senate Concurrent Resolution), hres (House Simple Resolution), sres (Senate Simple Resolution). Example: 'hr' for H.R. bills"
             ),
         ],
         limit: Annotated[
@@ -117,7 +117,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type (hr, s, hjres, etc.)")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
     ) -> dict[str, Any]:
         """Get detailed information about a specific bill.
@@ -131,7 +131,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill_actions(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -153,7 +153,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill_amendments(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -174,7 +174,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill_committees(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -196,7 +196,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill_cosponsors(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -218,7 +218,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill_related_bills(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -240,7 +240,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill_subjects(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -261,7 +261,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill_summaries(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -283,7 +283,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill_text(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -305,7 +305,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool()
     async def get_bill_titles(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="Bill type")],
+        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)

--- a/src/congress_mcp/tools/summaries.py
+++ b/src/congress_mcp/tools/summaries.py
@@ -56,7 +56,7 @@ def register_summary_tools(mcp: "FastMCP", config: Config) -> None:
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         bill_type: Annotated[
             BillType,
-            Field(description="Bill type: hr, s, hjres, sjres, hconres, sconres, hres, sres"),
+            Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills"),
         ],
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)


### PR DESCRIPTION
Explicitly marks bill_type parameters as REQUIRED and includes all enum values with a concrete example ('hr'). This defensive improvement helps LLM clients avoid defaulting to null when generating tool calls, reducing the chance of validation errors during MCP interactions.

## Changes
- Updated Field descriptions in `src/congress_mcp/tools/bills.py` (11 tools)
- Updated Field description in `src/congress_mcp/tools/summaries.py` (1 tool)
- All tests pass

🤖 Generated with Claude Code