### PR TITLE
Improve enum validation error messages for LLM clients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# Congress MCP Server
+
+## Project Overview
+
+MCP server providing access to U.S. Congress data via the Congress.gov API v3. Built with FastMCP and Pydantic.
+
+## Tech Stack
+
+- **Framework**: FastMCP >= 2.0.0 — [Docs](https://gofastmcp.com), [LLM reference](https://gofastmcp.com/llms.txt)
+- **Validation**: Pydantic >= 2.0.0
+- **HTTP Client**: httpx >= 0.27.0
+- **Python**: 3.12+
+- **Package Manager**: uv
+
+## Key Directories
+
+- `src/congress_mcp/` — Main source
+  - `server.py` — Entry point, creates FastMCP instance
+  - `client.py` — HTTP client with auth, pagination, and concurrent enrichment
+  - `types/enums.py` — 7 enum types (BillType, Chamber, AmendmentType, etc.)
+  - `tools/` — 18 modules, ~90 tool endpoints
+  - `exceptions.py` — Custom exception hierarchy
+- `tests/` — pytest test suite
+
+## Common Commands
+
+```bash
+uv run pytest tests/              # Run all tests
+uv run pytest tests/ -v           # Verbose test output
+uv run python -m congress_mcp     # Start the MCP server
+```
+
+## FastMCP Patterns
+
+- Tools use `@mcp.tool()` decorator with `Annotated[Type, Field(description=...)]`
+- `ToolError` from `fastmcp.exceptions` controls error messages sent to LLM clients
+- Middleware via `mcp.add_middleware()` can intercept tool calls with `on_call_tool`
+- Enums: clients send values (`"hr"`), not names (`"HR"`); functions receive enum members

--- a/src/congress_mcp/middleware.py
+++ b/src/congress_mcp/middleware.py
@@ -1,0 +1,112 @@
+"""Middleware for improving validation error messages for LLM clients."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+import mcp.types as mt
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+from pydantic import ValidationError
+
+from congress_mcp.types.enums import (
+    AmendmentType,
+    BillType,
+    Chamber,
+    HouseCommunicationType,
+    LawType,
+    ReportType,
+    SenateCommunicationType,
+)
+
+# Map parameter names to their enum class for prescriptive error messages.
+# communication_type is intentionally omitted — it requires disambiguation
+# between House and Senate based on the tool name (see _resolve_enum_class).
+ENUM_PARAMS: dict[str, type[Enum]] = {
+    "bill_type": BillType,
+    "chamber": Chamber,
+    "amendment_type": AmendmentType,
+    "law_type": LawType,
+    "report_type": ReportType,
+}
+
+
+def _resolve_enum_class(field_name: str, tool_name: str) -> type[Enum] | None:
+    """Resolve the enum class for a given parameter name and tool.
+
+    Handles the special case where ``communication_type`` maps to different
+    enum types depending on whether the tool is House or Senate.
+    """
+    if field_name == "communication_type":
+        if "house" in tool_name:
+            return HouseCommunicationType
+        return SenateCommunicationType
+    return ENUM_PARAMS.get(field_name)
+
+
+def _valid_values_str(enum_cls: type[Enum]) -> str:
+    return ", ".join(member.value for member in enum_cls)
+
+
+def _format_prescriptive_error(
+    field_name: str,
+    input_value: Any,
+    tool_name: str,
+) -> str | None:
+    """Build a prescriptive error message for an invalid enum value.
+
+    Returns ``None`` if *field_name* is not a recognised enum parameter.
+    """
+    enum_cls = _resolve_enum_class(field_name, tool_name)
+    if enum_cls is None:
+        return None
+
+    valid = _valid_values_str(enum_cls)
+
+    if input_value is None:
+        return (
+            f"null/None is not valid for '{field_name}'. "
+            f"This field is REQUIRED and cannot be null. "
+            f"Must be one of: {valid}. "
+            f"Please retry with one of these exact string values."
+        )
+
+    return (
+        f"'{input_value}' is not valid for '{field_name}'. "
+        f"Must be one of: {valid}. "
+        f"Please retry with one of these exact string values."
+    )
+
+
+class EnumValidationMiddleware(Middleware):
+    """Intercept Pydantic ``ValidationError`` for enum parameters and re-raise
+    as ``ToolError`` with prescriptive messages that help LLM clients
+    self-correct instead of retrying with the same invalid value."""
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        try:
+            return await call_next(context)
+        except ValidationError as exc:
+            tool_name = context.message.name
+            prescriptive_parts: list[str] = []
+
+            for error in exc.errors():
+                loc = error.get("loc", ())
+                field_name = str(loc[-1]) if loc else "unknown"
+                input_value = error.get("input")
+
+                msg = _format_prescriptive_error(field_name, input_value, tool_name)
+                if msg:
+                    prescriptive_parts.append(msg)
+
+            if prescriptive_parts:
+                raise ToolError("\n".join(prescriptive_parts)) from exc
+
+            # Non-enum validation error — re-raise with the original message
+            raise ToolError(str(exc)) from exc

--- a/src/congress_mcp/server.py
+++ b/src/congress_mcp/server.py
@@ -3,6 +3,7 @@
 from fastmcp import FastMCP
 
 from congress_mcp.config import Config
+from congress_mcp.middleware import EnumValidationMiddleware
 from congress_mcp.resources import register_all_resources
 from congress_mcp.tools import register_all_tools
 
@@ -40,6 +41,9 @@ Available data categories:
 - Roll call votes
 """,
 )
+
+# Add middleware for prescriptive enum validation errors
+mcp.add_middleware(EnumValidationMiddleware())
 
 # Register all tools and resources
 register_all_tools(mcp, config)

--- a/tests/test_enum_validation.py
+++ b/tests/test_enum_validation.py
@@ -1,0 +1,285 @@
+"""Tests for enum validation middleware."""
+
+from __future__ import annotations
+
+import pytest
+
+from congress_mcp.middleware import (
+    EnumValidationMiddleware,
+    _format_prescriptive_error,
+    _resolve_enum_class,
+)
+from congress_mcp.types.enums import (
+    AmendmentType,
+    BillType,
+    Chamber,
+    HouseCommunicationType,
+    LawType,
+    ReportType,
+    SenateCommunicationType,
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_enum_class
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEnumClass:
+    def test_bill_type(self) -> None:
+        assert _resolve_enum_class("bill_type", "get_bill") is BillType
+
+    def test_chamber(self) -> None:
+        assert _resolve_enum_class("chamber", "list_committees_by_chamber") is Chamber
+
+    def test_amendment_type(self) -> None:
+        assert _resolve_enum_class("amendment_type", "get_amendment") is AmendmentType
+
+    def test_law_type(self) -> None:
+        assert _resolve_enum_class("law_type", "get_law") is LawType
+
+    def test_report_type(self) -> None:
+        assert _resolve_enum_class("report_type", "get_committee_report") is ReportType
+
+    def test_communication_type_house(self) -> None:
+        assert (
+            _resolve_enum_class("communication_type", "list_house_communications")
+            is HouseCommunicationType
+        )
+
+    def test_communication_type_senate(self) -> None:
+        assert (
+            _resolve_enum_class("communication_type", "list_senate_communications")
+            is SenateCommunicationType
+        )
+
+    def test_communication_type_get_house(self) -> None:
+        assert (
+            _resolve_enum_class("communication_type", "get_house_communication")
+            is HouseCommunicationType
+        )
+
+    def test_communication_type_get_senate(self) -> None:
+        assert (
+            _resolve_enum_class("communication_type", "get_senate_communication")
+            is SenateCommunicationType
+        )
+
+    def test_unknown_field(self) -> None:
+        assert _resolve_enum_class("unknown_field", "some_tool") is None
+
+
+# ---------------------------------------------------------------------------
+# _format_prescriptive_error
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPrescriptiveError:
+    """Test prescriptive error message generation."""
+
+    # -- None/null inputs --------------------------------------------------
+
+    def test_none_bill_type(self) -> None:
+        msg = _format_prescriptive_error("bill_type", None, "get_bill")
+        assert msg is not None
+        assert "null/None is not valid" in msg
+        assert "REQUIRED" in msg
+        assert "hr" in msg
+        assert "sres" in msg
+        assert "Please retry" in msg
+
+    def test_none_chamber(self) -> None:
+        msg = _format_prescriptive_error("chamber", None, "list_hearings")
+        assert msg is not None
+        assert "null/None is not valid" in msg
+        assert "house" in msg
+        assert "senate" in msg
+
+    def test_none_amendment_type(self) -> None:
+        msg = _format_prescriptive_error("amendment_type", None, "get_amendment")
+        assert msg is not None
+        assert "hamdt" in msg
+        assert "samdt" in msg
+        assert "suamdt" in msg
+
+    def test_none_law_type(self) -> None:
+        msg = _format_prescriptive_error("law_type", None, "get_law")
+        assert msg is not None
+        assert "pub" in msg
+        assert "priv" in msg
+
+    def test_none_report_type(self) -> None:
+        msg = _format_prescriptive_error("report_type", None, "get_committee_report")
+        assert msg is not None
+        assert "hrpt" in msg
+        assert "srpt" in msg
+        assert "erpt" in msg
+
+    def test_none_house_communication_type(self) -> None:
+        msg = _format_prescriptive_error(
+            "communication_type", None, "list_house_communications"
+        )
+        assert msg is not None
+        assert "ec" in msg
+        assert "ml" in msg
+        # Confirm it is NOT showing Senate-only values
+        assert "pom" not in msg
+
+    def test_none_senate_communication_type(self) -> None:
+        msg = _format_prescriptive_error(
+            "communication_type", None, "list_senate_communications"
+        )
+        assert msg is not None
+        assert "ec" in msg
+        assert "pom" in msg
+        # Confirm it is NOT showing House-only values
+        assert "ml" not in msg
+
+    # -- Invalid string inputs ---------------------------------------------
+
+    def test_invalid_bill_type(self) -> None:
+        msg = _format_prescriptive_error("bill_type", "invalid", "get_bill")
+        assert msg is not None
+        assert "'invalid' is not valid" in msg
+        assert "hr" in msg
+        assert "REQUIRED" not in msg  # Only shown for None
+
+    def test_invalid_chamber(self) -> None:
+        msg = _format_prescriptive_error("chamber", "both", "list_hearings")
+        assert msg is not None
+        assert "'both' is not valid" in msg
+        assert "house" in msg
+        assert "senate" in msg
+
+    # -- Unknown fields return None ----------------------------------------
+
+    def test_unknown_field_returns_none(self) -> None:
+        assert _format_prescriptive_error("congress", 118, "get_bill") is None
+
+    def test_unknown_field_with_none_value(self) -> None:
+        assert _format_prescriptive_error("unknown", None, "some_tool") is None
+
+
+# ---------------------------------------------------------------------------
+# EnumValidationMiddleware integration
+# ---------------------------------------------------------------------------
+
+
+class TestEnumValidationMiddleware:
+    """Test the middleware catches ValidationError and raises ToolError."""
+
+    @pytest.fixture()
+    def middleware(self) -> EnumValidationMiddleware:
+        return EnumValidationMiddleware()
+
+    @pytest.mark.asyncio()
+    async def test_valid_call_passes_through(self, middleware: EnumValidationMiddleware) -> None:
+        """Middleware should not interfere with successful tool calls."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        sentinel = object()
+        call_next = AsyncMock(return_value=sentinel)
+
+        context = MagicMock()
+        context.message.name = "list_bills"
+
+        result = await middleware.on_call_tool(context, call_next)
+        assert result is sentinel
+        call_next.assert_awaited_once_with(context)
+
+    @pytest.mark.asyncio()
+    async def test_catches_enum_validation_error(
+        self, middleware: EnumValidationMiddleware
+    ) -> None:
+        """Middleware should convert enum ValidationError to ToolError."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from fastmcp.exceptions import ToolError
+        from pydantic import BaseModel, ValidationError
+
+        # Use a model with a named field to produce realistic loc tuples
+        class FakeBillParams(BaseModel):
+            bill_type: BillType
+
+        with pytest.raises(ValidationError) as exc_info:
+            FakeBillParams.model_validate({"bill_type": None})
+        pydantic_error = exc_info.value
+
+        call_next = AsyncMock(side_effect=pydantic_error)
+        context = MagicMock()
+        context.message.name = "list_bills_by_type"
+
+        with pytest.raises(ToolError) as tool_exc_info:
+            await middleware.on_call_tool(context, call_next)
+
+        error_msg = str(tool_exc_info.value)
+        assert "null/None is not valid" in error_msg
+        assert "bill_type" in error_msg
+        assert "hr" in error_msg
+        assert "Please retry" in error_msg
+
+    @pytest.mark.asyncio()
+    async def test_catches_invalid_string_validation_error(
+        self, middleware: EnumValidationMiddleware
+    ) -> None:
+        """Middleware should handle invalid string enum values."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from fastmcp.exceptions import ToolError
+        from pydantic import BaseModel, ValidationError
+
+        class FakeChamberParams(BaseModel):
+            chamber: Chamber
+
+        with pytest.raises(ValidationError) as exc_info:
+            FakeChamberParams.model_validate({"chamber": "both"})
+        pydantic_error = exc_info.value
+
+        call_next = AsyncMock(side_effect=pydantic_error)
+        context = MagicMock()
+        context.message.name = "list_committees_by_chamber"
+
+        with pytest.raises(ToolError) as tool_exc_info:
+            await middleware.on_call_tool(context, call_next)
+
+        error_msg = str(tool_exc_info.value)
+        assert "chamber" in error_msg
+        assert "house" in error_msg
+        assert "senate" in error_msg
+
+    @pytest.mark.asyncio()
+    async def test_non_enum_validation_error_still_raises_tool_error(
+        self, middleware: EnumValidationMiddleware
+    ) -> None:
+        """Non-enum ValidationErrors should still be caught and wrapped."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from fastmcp.exceptions import ToolError
+        from pydantic import TypeAdapter, ValidationError
+
+        # Create a non-enum validation error (int field getting a string)
+        adapter = TypeAdapter(int)
+        with pytest.raises(ValidationError) as exc_info:
+            adapter.validate_python("not_a_number")
+        pydantic_error = exc_info.value
+
+        call_next = AsyncMock(side_effect=pydantic_error)
+        context = MagicMock()
+        context.message.name = "list_bills"
+
+        with pytest.raises(ToolError):
+            await middleware.on_call_tool(context, call_next)
+
+    @pytest.mark.asyncio()
+    async def test_non_validation_errors_propagate(
+        self, middleware: EnumValidationMiddleware
+    ) -> None:
+        """Non-ValidationError exceptions should propagate unchanged."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        call_next = AsyncMock(side_effect=RuntimeError("something else"))
+        context = MagicMock()
+        context.message.name = "get_bill"
+
+        with pytest.raises(RuntimeError, match="something else"):
+            await middleware.on_call_tool(context, call_next)


### PR DESCRIPTION
## Summary

Add a FastMCP middleware that intercepts Pydantic ValidationError for enum parameters and re-raises as ToolError with prescriptive messages. This helps LLM clients (like Claude) self-correct instead of retrying with the same invalid null/None values.

## Implementation

- Created `EnumValidationMiddleware` in `src/congress_mcp/middleware.py` that catches validation errors for all 7 enum types across ~36 parameters
- Middleware generates prescriptive error messages like: "null/None is not valid for 'chamber'. This field is REQUIRED. Must be one of: house, senate. Please retry with one of these exact string values."
- Handles special case where `communication_type` maps to different enums (House vs Senate) based on tool name
- Created 26 comprehensive unit tests with 100% pass rate
- All 42 tests pass (26 new + 16 existing); zero regressions

## Testing

```bash
uv run --extra dev pytest tests/ -v --ignore=tests/test_integration_live.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)