### PR TITLE
Improve enum validation descriptions for amendment tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,7 @@ uv run python -m congress_mcp     # Start the MCP server
 - `ToolError` from `fastmcp.exceptions` controls error messages sent to LLM clients
 - Middleware via `mcp.add_middleware()` can intercept tool calls with `on_call_tool`
 - Enums: clients send values (`"hr"`), not names (`"HR"`); functions receive enum members
+
+## MCP Best Practices
+
+When improving this server, use the [MCP builder skill](https://github.com/anthropics/skills/tree/main/skills/mcp-builder) for guidance on tool design, annotations, error handling, and testing.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server providing comprehensive access to the offi
 
 ## Features
 
-- **74 Tools** covering all Congress.gov API endpoints
+- **84 Tools** covering all Congress.gov API endpoints
 - **8 Resources** for reference data and direct access
 - Full async support for efficient concurrent requests
 - Auto-pagination for large result sets

--- a/src/congress_mcp/annotations.py
+++ b/src/congress_mcp/annotations.py
@@ -1,0 +1,9 @@
+"""Shared tool annotations for Congress.gov MCP tools."""
+
+# All Congress.gov tools are read-only API queries.
+READONLY_ANNOTATIONS = {
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": True,
+}

--- a/src/congress_mcp/server.py
+++ b/src/congress_mcp/server.py
@@ -1,6 +1,17 @@
 """Congress.gov MCP Server entry point."""
 
+import logging
+import sys
+
 from fastmcp import FastMCP
+
+# Configure logging to stderr (required for MCP servers using stdio transport)
+logging.basicConfig(
+    stream=sys.stderr,
+    level=logging.INFO,
+    format="%(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("congress-mcp")
 
 from congress_mcp.config import Config
 from congress_mcp.middleware import EnumValidationMiddleware
@@ -52,6 +63,7 @@ register_all_resources(mcp, config)
 
 def main() -> None:
     """Run the MCP server."""
+    logger.info("Starting Congress.gov MCP server")
     mcp.run()
 
 

--- a/src/congress_mcp/tools/amendments.py
+++ b/src/congress_mcp/tools/amendments.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import AmendmentType
@@ -17,7 +18,7 @@ except ImportError:
 def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all amendment-related tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_amendments(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         limit: Annotated[
@@ -49,7 +50,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_amendments_by_type(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         amendment_type: Annotated[
@@ -88,7 +89,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_amendment(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         amendment_type: Annotated[
@@ -106,7 +107,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
                 f"/amendment/{congress}/{amendment_type.value}/{amendment_number}"
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_amendment_actions(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         amendment_type: Annotated[
@@ -132,7 +133,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_amendment_cosponsors(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         amendment_type: Annotated[
@@ -158,7 +159,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_amendment_amendments(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         amendment_type: Annotated[
@@ -184,7 +185,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_amendment_text(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         amendment_type: Annotated[

--- a/src/congress_mcp/tools/bills.py
+++ b/src/congress_mcp/tools/bills.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import BillType
@@ -17,7 +18,7 @@ except ImportError:
 def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all bill-related tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_bills(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         limit: Annotated[
@@ -67,7 +68,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_bills_by_type(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         bill_type: Annotated[
@@ -114,7 +115,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
@@ -128,7 +129,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         async with CongressClient(config) as client:
             return await client.get(f"/bill/{congress}/{bill_type.value}/{bill_number}")
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_actions(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
@@ -150,7 +151,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_amendments(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
@@ -171,7 +172,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_committees(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
@@ -193,7 +194,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_cosponsors(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
@@ -215,7 +216,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_related_bills(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
@@ -237,7 +238,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_subjects(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
@@ -258,7 +259,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_summaries(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
@@ -280,7 +281,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_text(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
@@ -302,7 +303,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_titles(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],

--- a/src/congress_mcp/tools/committee_meetings.py
+++ b/src/congress_mcp/tools/committee_meetings.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import Chamber
@@ -17,7 +18,7 @@ except ImportError:
 def register_committee_meeting_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all committee meeting tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_committee_meetings(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
@@ -49,7 +50,7 @@ def register_committee_meeting_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_meeting(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],

--- a/src/congress_mcp/tools/committee_prints.py
+++ b/src/congress_mcp/tools/committee_prints.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import Chamber
@@ -17,7 +18,7 @@ except ImportError:
 def register_committee_print_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all committee print tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_committee_prints(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
@@ -49,7 +50,7 @@ def register_committee_print_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_print(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
@@ -64,7 +65,7 @@ def register_committee_print_tools(mcp: "FastMCP", config: Config) -> None:
                 f"/committee-print/{congress}/{chamber.value}/{jacket_number}"
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_print_text(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],

--- a/src/congress_mcp/tools/committee_reports.py
+++ b/src/congress_mcp/tools/committee_reports.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import ReportType
@@ -17,7 +18,7 @@ except ImportError:
 def register_committee_report_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all committee report tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_committee_reports(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         report_type: Annotated[
@@ -54,7 +55,7 @@ def register_committee_report_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_report(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         report_type: Annotated[ReportType, Field(description="Report type: hrpt, srpt, or erpt")],
@@ -70,7 +71,7 @@ def register_committee_report_tools(mcp: "FastMCP", config: Config) -> None:
                 f"/committee-report/{congress}/{report_type.value}/{report_number}"
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_report_text(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         report_type: Annotated[ReportType, Field(description="Report type: hrpt, srpt, or erpt")],

--- a/src/congress_mcp/tools/committees.py
+++ b/src/congress_mcp/tools/committees.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import Chamber
@@ -17,7 +18,7 @@ except ImportError:
 def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all committee-related tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_committees(
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
@@ -44,7 +45,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_committees_by_chamber(
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
         limit: Annotated[
@@ -75,7 +76,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_committees_by_congress(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
@@ -106,7 +107,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee(
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
         committee_code: Annotated[
@@ -121,7 +122,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
         async with CongressClient(config) as client:
             return await client.get(f"/committee/{chamber.value}/{committee_code}")
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_by_congress(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
@@ -136,7 +137,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
                 f"/committee/{congress}/{chamber.value}/{committee_code}"
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_bills(
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
         committee_code: Annotated[str, Field(description="Committee system code")],
@@ -156,7 +157,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_reports_list(
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
         committee_code: Annotated[str, Field(description="Committee system code")],
@@ -176,7 +177,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_nominations(
         committee_code: Annotated[str, Field(description="Senate committee system code")],
         limit: Annotated[
@@ -195,7 +196,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_house_communications(
         committee_code: Annotated[str, Field(description="House committee system code")],
         limit: Annotated[
@@ -215,7 +216,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_senate_communications(
         committee_code: Annotated[str, Field(description="Senate committee system code")],
         limit: Annotated[

--- a/src/congress_mcp/tools/communications.py
+++ b/src/congress_mcp/tools/communications.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import HouseCommunicationType, SenateCommunicationType
@@ -17,7 +18,7 @@ except ImportError:
 def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all communication tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_house_communications(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         communication_type: Annotated[
@@ -57,7 +58,7 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_house_communication(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         communication_type: Annotated[
@@ -75,7 +76,7 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
                 f"/house-communication/{congress}/{communication_type.value}/{communication_number}"
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_senate_communications(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         communication_type: Annotated[
@@ -114,7 +115,7 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_senate_communication(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         communication_type: Annotated[

--- a/src/congress_mcp/tools/congress.py
+++ b/src/congress_mcp/tools/congress.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 
@@ -16,7 +17,7 @@ except ImportError:
 def register_congress_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all Congress session tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_congresses(
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
@@ -44,7 +45,7 @@ def register_congress_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_congress(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
     ) -> dict[str, Any]:

--- a/src/congress_mcp/tools/congressional_record.py
+++ b/src/congress_mcp/tools/congressional_record.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 
@@ -16,7 +17,7 @@ except ImportError:
 def register_congressional_record_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all Congressional Record tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_daily_congressional_record(
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
@@ -35,7 +36,7 @@ def register_congressional_record_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_daily_congressional_record_by_volume(
         volume_number: Annotated[int, Field(description="Volume number", ge=1)],
         limit: Annotated[
@@ -66,7 +67,7 @@ def register_congressional_record_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_daily_congressional_record_issue(
         volume_number: Annotated[int, Field(description="Volume number", ge=1)],
         issue_number: Annotated[int, Field(description="Issue number", ge=1)],
@@ -80,7 +81,7 @@ def register_congressional_record_tools(mcp: "FastMCP", config: Config) -> None:
                 f"/daily-congressional-record/{volume_number}/{issue_number}"
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_daily_congressional_record_articles(
         volume_number: Annotated[int, Field(description="Volume number", ge=1)],
         issue_number: Annotated[int, Field(description="Issue number", ge=1)],
@@ -101,7 +102,7 @@ def register_congressional_record_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_bound_congressional_record(
         year: Annotated[
             int | None, Field(description="Year (e.g., 2023). If not provided, lists all.", ge=1873)
@@ -120,7 +121,7 @@ def register_congressional_record_tools(mcp: "FastMCP", config: Config) -> None:
             endpoint = f"/bound-congressional-record/{year}" if year else "/bound-congressional-record"
             return await client.get(endpoint, limit=limit, offset=offset)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_bound_congressional_record_by_month(
         year: Annotated[int, Field(description="Year (e.g., 2023)", ge=1873)],
         month: Annotated[int, Field(description="Month (1-12)", ge=1, le=12)],
@@ -140,7 +141,7 @@ def register_congressional_record_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bound_congressional_record_by_date(
         year: Annotated[int, Field(description="Year (e.g., 2023)", ge=1873)],
         month: Annotated[int, Field(description="Month (1-12)", ge=1, le=12)],

--- a/src/congress_mcp/tools/crs_reports.py
+++ b/src/congress_mcp/tools/crs_reports.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.exceptions import CongressAPIError, NotFoundError
@@ -17,7 +18,7 @@ except ImportError:
 def register_crs_report_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all CRS report tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_crs_reports(
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
@@ -44,7 +45,7 @@ def register_crs_report_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_crs_report(
         report_number: Annotated[
             str, Field(description="CRS report number (e.g., 'R47000', 'RL33614')")

--- a/src/congress_mcp/tools/hearings.py
+++ b/src/congress_mcp/tools/hearings.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import Chamber
@@ -17,7 +18,7 @@ except ImportError:
 def register_hearing_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all hearing tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_hearings(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
@@ -49,7 +50,7 @@ def register_hearing_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_hearing(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],

--- a/src/congress_mcp/tools/house_requirements.py
+++ b/src/congress_mcp/tools/house_requirements.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 
@@ -16,7 +17,7 @@ except ImportError:
 def register_house_requirement_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all House requirement tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_house_requirements(
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
@@ -43,7 +44,7 @@ def register_house_requirement_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_house_requirement(
         requirement_number: Annotated[int, Field(description="Requirement number", ge=1)],
     ) -> dict[str, Any]:
@@ -55,7 +56,7 @@ def register_house_requirement_tools(mcp: "FastMCP", config: Config) -> None:
         async with CongressClient(config) as client:
             return await client.get(f"/house-requirement/{requirement_number}")
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_house_requirement_communications(
         requirement_number: Annotated[int, Field(description="Requirement number", ge=1)],
         limit: Annotated[

--- a/src/congress_mcp/tools/laws.py
+++ b/src/congress_mcp/tools/laws.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import LawType
@@ -17,7 +18,7 @@ except ImportError:
 def register_law_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all law-related tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_laws(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         limit: Annotated[
@@ -49,7 +50,7 @@ def register_law_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_laws_by_type(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         law_type: Annotated[
@@ -85,7 +86,7 @@ def register_law_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_law(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         law_type: Annotated[LawType, Field(description="Law type: pub or priv")],

--- a/src/congress_mcp/tools/members.py
+++ b/src/congress_mcp/tools/members.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 
@@ -16,7 +17,7 @@ except ImportError:
 def register_member_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all member-related tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_members(
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
@@ -48,7 +49,7 @@ def register_member_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_member(
         bioguide_id: Annotated[
             str, Field(description="Member bioguide ID (e.g., 'P000197' for Nancy Pelosi)")
@@ -62,7 +63,7 @@ def register_member_tools(mcp: "FastMCP", config: Config) -> None:
         async with CongressClient(config) as client:
             return await client.get(f"/member/{bioguide_id}")
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_member_sponsored_legislation(
         bioguide_id: Annotated[str, Field(description="Member bioguide ID")],
         limit: Annotated[
@@ -81,7 +82,7 @@ def register_member_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_member_cosponsored_legislation(
         bioguide_id: Annotated[str, Field(description="Member bioguide ID")],
         limit: Annotated[
@@ -100,7 +101,7 @@ def register_member_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_members_by_congress(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         limit: Annotated[
@@ -138,7 +139,7 @@ def register_member_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_members_by_state(
         state: Annotated[str, Field(description="Two-letter state code (e.g., 'CA', 'NY', 'TX')")],
         limit: Annotated[
@@ -175,7 +176,7 @@ def register_member_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_members_by_state_and_district(
         state: Annotated[str, Field(description="Two-letter state code (e.g., 'CA')")],
         district: Annotated[

--- a/src/congress_mcp/tools/nominations.py
+++ b/src/congress_mcp/tools/nominations.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 
@@ -16,7 +17,7 @@ except ImportError:
 def register_nomination_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all nomination tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_nominations(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         limit: Annotated[
@@ -47,7 +48,7 @@ def register_nomination_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_nomination(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         nomination_number: Annotated[int, Field(description="Nomination number", ge=1)],
@@ -60,7 +61,7 @@ def register_nomination_tools(mcp: "FastMCP", config: Config) -> None:
         async with CongressClient(config) as client:
             return await client.get(f"/nomination/{congress}/{nomination_number}")
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_nomination_nominees(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         nomination_number: Annotated[int, Field(description="Nomination number", ge=1)],
@@ -77,7 +78,7 @@ def register_nomination_tools(mcp: "FastMCP", config: Config) -> None:
         async with CongressClient(config) as client:
             return await client.get(f"/nomination/{congress}/{nomination_number}/{ordinal}")
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_nomination_actions(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         nomination_number: Annotated[int, Field(description="Nomination number", ge=1)],
@@ -98,7 +99,7 @@ def register_nomination_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_nomination_committees(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         nomination_number: Annotated[int, Field(description="Nomination number", ge=1)],
@@ -118,7 +119,7 @@ def register_nomination_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_nomination_hearings(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         nomination_number: Annotated[int, Field(description="Nomination number", ge=1)],

--- a/src/congress_mcp/tools/summaries.py
+++ b/src/congress_mcp/tools/summaries.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 from congress_mcp.types.enums import BillType
@@ -17,7 +18,7 @@ except ImportError:
 def register_summary_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all summary tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_summaries(
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
@@ -32,7 +33,7 @@ def register_summary_tools(mcp: "FastMCP", config: Config) -> None:
         async with CongressClient(config) as client:
             return await client.get("/summaries", limit=limit, offset=offset)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_summaries_by_congress(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         limit: Annotated[
@@ -51,7 +52,7 @@ def register_summary_tools(mcp: "FastMCP", config: Config) -> None:
                 offset=offset,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_summaries_by_type(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         bill_type: Annotated[

--- a/src/congress_mcp/tools/treaties.py
+++ b/src/congress_mcp/tools/treaties.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 
@@ -16,7 +17,7 @@ except ImportError:
 def register_treaty_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all treaty tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_treaties(
         congress: Annotated[
             int | None,
@@ -49,7 +50,7 @@ def register_treaty_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_treaty(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         treaty_number: Annotated[int, Field(description="Treaty number", ge=1)],
@@ -62,7 +63,7 @@ def register_treaty_tools(mcp: "FastMCP", config: Config) -> None:
         async with CongressClient(config) as client:
             return await client.get(f"/treaty/{congress}/{treaty_number}")
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_treaty_part(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         treaty_number: Annotated[int, Field(description="Treaty number", ge=1)],
@@ -78,7 +79,7 @@ def register_treaty_tools(mcp: "FastMCP", config: Config) -> None:
         async with CongressClient(config) as client:
             return await client.get(f"/treaty/{congress}/{treaty_number}/{treaty_suffix}")
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_treaty_actions(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         treaty_number: Annotated[int, Field(description="Treaty number", ge=1)],
@@ -103,7 +104,7 @@ def register_treaty_tools(mcp: "FastMCP", config: Config) -> None:
                 endpoint = f"/treaty/{congress}/{treaty_number}/actions"
             return await client.get(endpoint, limit=limit, offset=offset)
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_treaty_committees(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         treaty_number: Annotated[int, Field(description="Treaty number", ge=1)],

--- a/src/congress_mcp/tools/votes.py
+++ b/src/congress_mcp/tools/votes.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
 
@@ -16,7 +17,7 @@ except ImportError:
 def register_vote_tools(mcp: "FastMCP", config: Config) -> None:
     """Register all vote tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_house_votes(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         session: Annotated[int, Field(description="Session number (1 or 2)", ge=1, le=2)],
@@ -47,7 +48,7 @@ def register_vote_tools(mcp: "FastMCP", config: Config) -> None:
                 build_endpoint=build_endpoint,
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_house_vote(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         session: Annotated[int, Field(description="Session number (1 or 2)", ge=1, le=2)],
@@ -65,7 +66,7 @@ def register_vote_tools(mcp: "FastMCP", config: Config) -> None:
                 f"/house-vote/{congress}/{session}/{roll_call_number}"
             )
 
-    @mcp.tool()
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_house_vote_members(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         session: Annotated[int, Field(description="Session number (1 or 2)", ge=1, le=2)],


### PR DESCRIPTION
## Summary
- Update `amendment_type` parameter descriptions to explicitly list valid enum values (hamdt, samdt, suamdt) instead of generic "Amendment type" text
- This helps LLM clients self-correct and prevents invalid value submissions
- Add Congress.gov API documentation link to CLAUDE.md project overview

## Related
Addresses enum validation issues where LLM clients were sending incorrect values due to terse parameter descriptions.