### PR TITLE
Fix enum  schema issue causing boolean type confusion

### DIFF
--- a/src/congress_mcp/middleware.py
+++ b/src/congress_mcp/middleware.py
@@ -73,6 +73,15 @@ def _format_prescriptive_error(
             f"Please retry with one of these exact string values."
         )
 
+    if isinstance(input_value, bool):
+        example = next(iter(enum_cls)).value
+        return (
+            f"Boolean {input_value} is not valid for '{field_name}'. "
+            f"This field requires a STRING value, not a boolean. "
+            f"Must be one of: {valid}. "
+            f'Please retry with one of these exact string values (e.g. "{example}").'
+        )
+
     return (
         f"'{input_value}' is not valid for '{field_name}'. "
         f"Must be one of: {valid}. "

--- a/src/congress_mcp/tools/amendments.py
+++ b/src/congress_mcp/tools/amendments.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
-from congress_mcp.types.enums import AmendmentType
+from congress_mcp.types.enums import AmendmentTypeLiteral
 
 try:
     from fastmcp import FastMCP
@@ -54,7 +54,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
     async def list_amendments_by_type(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         amendment_type: Annotated[
-            AmendmentType,
+            AmendmentTypeLiteral,
             Field(
                 description="Amendment type: hamdt (House), samdt (Senate), suamdt (Senate Unprinted)"
             ),
@@ -73,14 +73,14 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             response = await client.get(
-                f"/amendment/{congress}/{amendment_type.value}",
+                f"/amendment/{congress}/{amendment_type}",
                 limit=limit,
                 offset=offset,
             )
 
             def build_endpoint(item: dict[str, Any]) -> str:
                 amdt_number = item.get("number", "")
-                return f"/amendment/{congress}/{amendment_type.value}/{amdt_number}"
+                return f"/amendment/{congress}/{amendment_type}/{amdt_number}"
 
             return await client.enrich_list_response(
                 response,
@@ -93,7 +93,10 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
     async def get_amendment(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         amendment_type: Annotated[
-            AmendmentType, Field(description="Amendment type: hamdt, samdt, or suamdt")
+            AmendmentTypeLiteral,
+            Field(
+                description="Amendment type: hamdt (House), samdt (Senate), suamdt (Senate Unprinted)"
+            ),
         ],
         amendment_number: Annotated[int, Field(description="Amendment number", ge=1)],
     ) -> dict[str, Any]:
@@ -104,14 +107,14 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/amendment/{congress}/{amendment_type.value}/{amendment_number}"
+                f"/amendment/{congress}/{amendment_type}/{amendment_number}"
             )
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_amendment_actions(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         amendment_type: Annotated[
-            AmendmentType,
+            AmendmentTypeLiteral,
             Field(
                 description="Amendment type: hamdt (House), samdt (Senate), suamdt (Senate Unprinted)"
             ),
@@ -128,7 +131,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/amendment/{congress}/{amendment_type.value}/{amendment_number}/actions",
+                f"/amendment/{congress}/{amendment_type}/{amendment_number}/actions",
                 limit=limit,
                 offset=offset,
             )
@@ -137,7 +140,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
     async def get_amendment_cosponsors(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         amendment_type: Annotated[
-            AmendmentType,
+            AmendmentTypeLiteral,
             Field(
                 description="Amendment type: hamdt (House), samdt (Senate), suamdt (Senate Unprinted)"
             ),
@@ -154,7 +157,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/amendment/{congress}/{amendment_type.value}/{amendment_number}/cosponsors",
+                f"/amendment/{congress}/{amendment_type}/{amendment_number}/cosponsors",
                 limit=limit,
                 offset=offset,
             )
@@ -163,7 +166,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
     async def get_amendment_amendments(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         amendment_type: Annotated[
-            AmendmentType,
+            AmendmentTypeLiteral,
             Field(
                 description="Amendment type: hamdt (House), samdt (Senate), suamdt (Senate Unprinted)"
             ),
@@ -180,7 +183,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/amendment/{congress}/{amendment_type.value}/{amendment_number}/amendments",
+                f"/amendment/{congress}/{amendment_type}/{amendment_number}/amendments",
                 limit=limit,
                 offset=offset,
             )
@@ -189,7 +192,7 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
     async def get_amendment_text(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
         amendment_type: Annotated[
-            AmendmentType,
+            AmendmentTypeLiteral,
             Field(
                 description="Amendment type: hamdt (House), samdt (Senate), suamdt (Senate Unprinted)"
             ),
@@ -203,5 +206,5 @@ def register_amendment_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/amendment/{congress}/{amendment_type.value}/{amendment_number}/text"
+                f"/amendment/{congress}/{amendment_type}/{amendment_number}/text"
             )

--- a/src/congress_mcp/tools/bills.py
+++ b/src/congress_mcp/tools/bills.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
-from congress_mcp.types.enums import BillType
+from congress_mcp.types.enums import BillTypeLiteral
 
 try:
     from fastmcp import FastMCP
@@ -72,7 +72,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     async def list_bills_by_type(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         bill_type: Annotated[
-            BillType,
+            BillTypeLiteral,
             Field(
                 description="REQUIRED bill type string. Must be one of: hr (House Bill), s (Senate Bill), hjres (House Joint Resolution), sjres (Senate Joint Resolution), hconres (House Concurrent Resolution), sconres (Senate Concurrent Resolution), hres (House Simple Resolution), sres (Senate Simple Resolution). Example: 'hr' for H.R. bills"
             ),
@@ -99,14 +99,14 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             response = await client.get(
-                f"/bill/{congress}/{bill_type.value}",
+                f"/bill/{congress}/{bill_type}",
                 limit=limit,
                 offset=offset,
             )
 
             def build_endpoint(item: dict[str, Any]) -> str:
                 bill_number = item.get("number", "")
-                return f"/bill/{congress}/{bill_type.value}/{bill_number}"
+                return f"/bill/{congress}/{bill_type}/{bill_number}"
 
             return await client.enrich_list_response(
                 response,
@@ -118,7 +118,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
     ) -> dict[str, Any]:
         """Get detailed information about a specific bill.
@@ -127,12 +127,12 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         committees, actions, related bills, subjects, and text versions.
         """
         async with CongressClient(config) as client:
-            return await client.get(f"/bill/{congress}/{bill_type.value}/{bill_number}")
+            return await client.get(f"/bill/{congress}/{bill_type}/{bill_number}")
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_actions(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -146,7 +146,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/bill/{congress}/{bill_type.value}/{bill_number}/actions",
+                f"/bill/{congress}/{bill_type}/{bill_number}/actions",
                 limit=limit,
                 offset=offset,
             )
@@ -154,7 +154,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_amendments(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -167,7 +167,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/bill/{congress}/{bill_type.value}/{bill_number}/amendments",
+                f"/bill/{congress}/{bill_type}/{bill_number}/amendments",
                 limit=limit,
                 offset=offset,
             )
@@ -175,7 +175,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_committees(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -189,7 +189,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/bill/{congress}/{bill_type.value}/{bill_number}/committees",
+                f"/bill/{congress}/{bill_type}/{bill_number}/committees",
                 limit=limit,
                 offset=offset,
             )
@@ -197,7 +197,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_cosponsors(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -211,7 +211,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/bill/{congress}/{bill_type.value}/{bill_number}/cosponsors",
+                f"/bill/{congress}/{bill_type}/{bill_number}/cosponsors",
                 limit=limit,
                 offset=offset,
             )
@@ -219,7 +219,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_related_bills(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -233,7 +233,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/bill/{congress}/{bill_type.value}/{bill_number}/relatedbills",
+                f"/bill/{congress}/{bill_type}/{bill_number}/relatedbills",
                 limit=limit,
                 offset=offset,
             )
@@ -241,7 +241,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_subjects(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -254,7 +254,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/bill/{congress}/{bill_type.value}/{bill_number}/subjects",
+                f"/bill/{congress}/{bill_type}/{bill_number}/subjects",
                 limit=limit,
                 offset=offset,
             )
@@ -262,7 +262,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_summaries(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -276,7 +276,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/bill/{congress}/{bill_type.value}/{bill_number}/summaries",
+                f"/bill/{congress}/{bill_type}/{bill_number}/summaries",
                 limit=limit,
                 offset=offset,
             )
@@ -284,7 +284,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_text(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -298,7 +298,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/bill/{congress}/{bill_type.value}/{bill_number}/text",
+                f"/bill/{congress}/{bill_type}/{bill_number}/text",
                 limit=limit,
                 offset=offset,
             )
@@ -306,7 +306,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_bill_titles(
         congress: Annotated[int, Field(description="Congress number", ge=1, le=200)],
-        bill_type: Annotated[BillType, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
+        bill_type: Annotated[BillTypeLiteral, Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills")],
         bill_number: Annotated[int, Field(description="Bill number", ge=1)],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -320,7 +320,7 @@ def register_bill_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/bill/{congress}/{bill_type.value}/{bill_number}/titles",
+                f"/bill/{congress}/{bill_type}/{bill_number}/titles",
                 limit=limit,
                 offset=offset,
             )

--- a/src/congress_mcp/tools/committee_prints.py
+++ b/src/congress_mcp/tools/committee_prints.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
-from congress_mcp.types.enums import Chamber
+from congress_mcp.types.enums import ChamberLiteral
 
 try:
     from fastmcp import FastMCP
@@ -21,7 +21,7 @@ def register_committee_print_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_committee_prints(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
         ] = None,
@@ -34,14 +34,14 @@ def register_committee_print_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             response = await client.get(
-                f"/committee-print/{congress}/{chamber.value}",
+                f"/committee-print/{congress}/{chamber}",
                 limit=limit,
                 offset=offset,
             )
 
             def build_endpoint(item: dict[str, Any]) -> str:
                 jacket_number = item.get("jacketNumber", "")
-                return f"/committee-print/{congress}/{chamber.value}/{jacket_number}"
+                return f"/committee-print/{congress}/{chamber}/{jacket_number}"
 
             return await client.enrich_list_response(
                 response,
@@ -53,7 +53,7 @@ def register_committee_print_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_print(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         jacket_number: Annotated[str, Field(description="Print jacket number")],
     ) -> dict[str, Any]:
         """Get detailed information about a specific committee print.
@@ -62,13 +62,13 @@ def register_committee_print_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/committee-print/{congress}/{chamber.value}/{jacket_number}"
+                f"/committee-print/{congress}/{chamber}/{jacket_number}"
             )
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_print_text(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         jacket_number: Annotated[str, Field(description="Print jacket number")],
     ) -> dict[str, Any]:
         """Get text versions of a committee print.
@@ -77,5 +77,5 @@ def register_committee_print_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/committee-print/{congress}/{chamber.value}/{jacket_number}/text"
+                f"/committee-print/{congress}/{chamber}/{jacket_number}/text"
             )

--- a/src/congress_mcp/tools/committee_reports.py
+++ b/src/congress_mcp/tools/committee_reports.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
-from congress_mcp.types.enums import ReportType
+from congress_mcp.types.enums import ReportTypeLiteral
 
 try:
     from fastmcp import FastMCP
@@ -22,7 +22,7 @@ def register_committee_report_tools(mcp: "FastMCP", config: Config) -> None:
     async def list_committee_reports(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         report_type: Annotated[
-            ReportType,
+            ReportTypeLiteral,
             Field(description="Report type: hrpt (House), srpt (Senate), erpt (Executive)"),
         ],
         limit: Annotated[
@@ -39,14 +39,14 @@ def register_committee_report_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             response = await client.get(
-                f"/committee-report/{congress}/{report_type.value}",
+                f"/committee-report/{congress}/{report_type}",
                 limit=limit,
                 offset=offset,
             )
 
             def build_endpoint(item: dict[str, Any]) -> str:
                 report_number = item.get("number", "")
-                return f"/committee-report/{congress}/{report_type.value}/{report_number}"
+                return f"/committee-report/{congress}/{report_type}/{report_number}"
 
             return await client.enrich_list_response(
                 response,
@@ -58,7 +58,7 @@ def register_committee_report_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_report(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        report_type: Annotated[ReportType, Field(description="Report type: hrpt, srpt, or erpt")],
+        report_type: Annotated[ReportTypeLiteral, Field(description="Report type: hrpt, srpt, or erpt")],
         report_number: Annotated[int, Field(description="Report number", ge=1)],
     ) -> dict[str, Any]:
         """Get detailed information about a specific committee report.
@@ -68,13 +68,13 @@ def register_committee_report_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/committee-report/{congress}/{report_type.value}/{report_number}"
+                f"/committee-report/{congress}/{report_type}/{report_number}"
             )
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_report_text(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        report_type: Annotated[ReportType, Field(description="Report type: hrpt, srpt, or erpt")],
+        report_type: Annotated[ReportTypeLiteral, Field(description="Report type: hrpt, srpt, or erpt")],
         report_number: Annotated[int, Field(description="Report number", ge=1)],
     ) -> dict[str, Any]:
         """Get text versions of a committee report.
@@ -83,5 +83,5 @@ def register_committee_report_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/committee-report/{congress}/{report_type.value}/{report_number}/text"
+                f"/committee-report/{congress}/{report_type}/{report_number}/text"
             )

--- a/src/congress_mcp/tools/committees.py
+++ b/src/congress_mcp/tools/committees.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
-from congress_mcp.types.enums import Chamber
+from congress_mcp.types.enums import ChamberLiteral
 
 try:
     from fastmcp import FastMCP
@@ -47,7 +47,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_committees_by_chamber(
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
         ] = None,
@@ -60,14 +60,14 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             response = await client.get(
-                f"/committee/{chamber.value}",
+                f"/committee/{chamber}",
                 limit=limit,
                 offset=offset,
             )
 
             def build_endpoint(item: dict[str, Any]) -> str:
                 system_code = item.get("systemCode", "")
-                return f"/committee/{chamber.value}/{system_code}"
+                return f"/committee/{chamber}/{system_code}"
 
             return await client.enrich_list_response(
                 response,
@@ -79,7 +79,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_committees_by_congress(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
         ] = None,
@@ -91,14 +91,14 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             response = await client.get(
-                f"/committee/{congress}/{chamber.value}",
+                f"/committee/{congress}/{chamber}",
                 limit=limit,
                 offset=offset,
             )
 
             def build_endpoint(item: dict[str, Any]) -> str:
                 system_code = item.get("systemCode", "")
-                return f"/committee/{congress}/{chamber.value}/{system_code}"
+                return f"/committee/{congress}/{chamber}/{system_code}"
 
             return await client.enrich_list_response(
                 response,
@@ -109,7 +109,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee(
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         committee_code: Annotated[
             str, Field(description="Committee system code (e.g., 'hsju00' for House Judiciary)")
         ],
@@ -120,12 +120,12 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
         and historical information.
         """
         async with CongressClient(config) as client:
-            return await client.get(f"/committee/{chamber.value}/{committee_code}")
+            return await client.get(f"/committee/{chamber}/{committee_code}")
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_by_congress(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         committee_code: Annotated[str, Field(description="Committee system code")],
     ) -> dict[str, Any]:
         """Get committee information for a specific Congress.
@@ -134,12 +134,12 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/committee/{congress}/{chamber.value}/{committee_code}"
+                f"/committee/{congress}/{chamber}/{committee_code}"
             )
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_bills(
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         committee_code: Annotated[str, Field(description="Committee system code")],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -152,14 +152,14 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/committee/{chamber.value}/{committee_code}/bills",
+                f"/committee/{chamber}/{committee_code}/bills",
                 limit=limit,
                 offset=offset,
             )
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_committee_reports_list(
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         committee_code: Annotated[str, Field(description="Committee system code")],
         limit: Annotated[
             int | None, Field(description="Maximum results to return", ge=1, le=250)
@@ -172,7 +172,7 @@ def register_committee_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/committee/{chamber.value}/{committee_code}/reports",
+                f"/committee/{chamber}/{committee_code}/reports",
                 limit=limit,
                 offset=offset,
             )

--- a/src/congress_mcp/tools/communications.py
+++ b/src/congress_mcp/tools/communications.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
-from congress_mcp.types.enums import HouseCommunicationType, SenateCommunicationType
+from congress_mcp.types.enums import HouseCommunicationTypeLiteral, SenateCommunicationTypeLiteral
 
 try:
     from fastmcp import FastMCP
@@ -22,7 +22,7 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
     async def list_house_communications(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         communication_type: Annotated[
-            HouseCommunicationType,
+            HouseCommunicationTypeLiteral,
             Field(
                 description="Communication type: ec (Executive), pm (Presidential Message), pt (Petition), ml (Memorial)"
             ),
@@ -42,14 +42,14 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             response = await client.get(
-                f"/house-communication/{congress}/{communication_type.value}",
+                f"/house-communication/{congress}/{communication_type}",
                 limit=limit,
                 offset=offset,
             )
 
             def build_endpoint(item: dict[str, Any]) -> str:
                 comm_number = item.get("number", "")
-                return f"/house-communication/{congress}/{communication_type.value}/{comm_number}"
+                return f"/house-communication/{congress}/{communication_type}/{comm_number}"
 
             return await client.enrich_list_response(
                 response,
@@ -62,7 +62,7 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
     async def get_house_communication(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         communication_type: Annotated[
-            HouseCommunicationType, Field(description="Communication type: ec, pm, pt, or ml")
+            HouseCommunicationTypeLiteral, Field(description="Communication type: ec, pm, pt, or ml")
         ],
         communication_number: Annotated[int, Field(description="Communication number", ge=1)],
     ) -> dict[str, Any]:
@@ -73,14 +73,14 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/house-communication/{congress}/{communication_type.value}/{communication_number}"
+                f"/house-communication/{congress}/{communication_type}/{communication_number}"
             )
 
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_senate_communications(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         communication_type: Annotated[
-            SenateCommunicationType,
+            SenateCommunicationTypeLiteral,
             Field(
                 description="Communication type: ec (Executive), pom (Petition/Memorial), pm (Presidential Message)"
             ),
@@ -99,14 +99,14 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             response = await client.get(
-                f"/senate-communication/{congress}/{communication_type.value}",
+                f"/senate-communication/{congress}/{communication_type}",
                 limit=limit,
                 offset=offset,
             )
 
             def build_endpoint(item: dict[str, Any]) -> str:
                 comm_number = item.get("number", "")
-                return f"/senate-communication/{congress}/{communication_type.value}/{comm_number}"
+                return f"/senate-communication/{congress}/{communication_type}/{comm_number}"
 
             return await client.enrich_list_response(
                 response,
@@ -119,7 +119,7 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
     async def get_senate_communication(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         communication_type: Annotated[
-            SenateCommunicationType, Field(description="Communication type: ec, pom, or pm")
+            SenateCommunicationTypeLiteral, Field(description="Communication type: ec, pom, or pm")
         ],
         communication_number: Annotated[int, Field(description="Communication number", ge=1)],
     ) -> dict[str, Any]:
@@ -130,5 +130,5 @@ def register_communication_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/senate-communication/{congress}/{communication_type.value}/{communication_number}"
+                f"/senate-communication/{congress}/{communication_type}/{communication_number}"
             )

--- a/src/congress_mcp/tools/hearings.py
+++ b/src/congress_mcp/tools/hearings.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
-from congress_mcp.types.enums import Chamber
+from congress_mcp.types.enums import ChamberLiteral
 
 try:
     from fastmcp import FastMCP
@@ -21,7 +21,7 @@ def register_hearing_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def list_hearings(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         limit: Annotated[
             int | None, Field(description="Maximum results to return (1-250)", ge=1, le=250)
         ] = None,
@@ -34,14 +34,14 @@ def register_hearing_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             response = await client.get(
-                f"/hearing/{congress}/{chamber.value}",
+                f"/hearing/{congress}/{chamber}",
                 limit=limit,
                 offset=offset,
             )
 
             def build_endpoint(item: dict[str, Any]) -> str:
                 jacket_number = item.get("jacketNumber", "")
-                return f"/hearing/{congress}/{chamber.value}/{jacket_number}"
+                return f"/hearing/{congress}/{chamber}/{jacket_number}"
 
             return await client.enrich_list_response(
                 response,
@@ -53,7 +53,7 @@ def register_hearing_tools(mcp: "FastMCP", config: Config) -> None:
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def get_hearing(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
-        chamber: Annotated[Chamber, Field(description="Chamber: house or senate")],
+        chamber: Annotated[ChamberLiteral, Field(description="Chamber: house or senate")],
         jacket_number: Annotated[str, Field(description="Hearing jacket number")],
     ) -> dict[str, Any]:
         """Get detailed information about a specific hearing.
@@ -62,4 +62,4 @@ def register_hearing_tools(mcp: "FastMCP", config: Config) -> None:
         witnesses, and links to transcript.
         """
         async with CongressClient(config) as client:
-            return await client.get(f"/hearing/{congress}/{chamber.value}/{jacket_number}")
+            return await client.get(f"/hearing/{congress}/{chamber}/{jacket_number}")

--- a/src/congress_mcp/tools/summaries.py
+++ b/src/congress_mcp/tools/summaries.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from congress_mcp.annotations import READONLY_ANNOTATIONS
 from congress_mcp.client import CongressClient
 from congress_mcp.config import Config
-from congress_mcp.types.enums import BillType
+from congress_mcp.types.enums import BillTypeLiteral
 
 try:
     from fastmcp import FastMCP
@@ -56,7 +56,7 @@ def register_summary_tools(mcp: "FastMCP", config: Config) -> None:
     async def list_summaries_by_type(
         congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
         bill_type: Annotated[
-            BillType,
+            BillTypeLiteral,
             Field(description="REQUIRED bill type string. Must be one of: hr, s, hjres, sjres, hconres, sconres, hres, sres. Example: 'hr' for H.R. bills"),
         ],
         limit: Annotated[
@@ -70,7 +70,7 @@ def register_summary_tools(mcp: "FastMCP", config: Config) -> None:
         """
         async with CongressClient(config) as client:
             return await client.get(
-                f"/summaries/{congress}/{bill_type.value}",
+                f"/summaries/{congress}/{bill_type}",
                 limit=limit,
                 offset=offset,
             )

--- a/src/congress_mcp/types/enums.py
+++ b/src/congress_mcp/types/enums.py
@@ -1,6 +1,13 @@
-"""Enumeration types for Congress.gov API parameters."""
+"""Enumeration types for Congress.gov API parameters.
+
+Enum classes are used for middleware validation error messages.
+Literal types are used in tool parameter signatures to produce flat
+JSON schemas without ``$ref``/``$defs`` indirection, which improves
+compatibility with LLM tool-calling clients.
+"""
 
 from enum import Enum
+from typing import Literal
 
 
 class BillType(str, Enum):
@@ -19,6 +26,9 @@ class BillType(str, Enum):
     SRES = "sres"  # Senate Simple Resolution
 
 
+BillTypeLiteral = Literal["hr", "s", "hjres", "sjres", "hconres", "sconres", "hres", "sres"]
+
+
 class AmendmentType(str, Enum):
     """Amendment type codes.
 
@@ -32,11 +42,17 @@ class AmendmentType(str, Enum):
     SUAMDT = "suamdt"
 
 
+AmendmentTypeLiteral = Literal["hamdt", "samdt", "suamdt"]
+
+
 class Chamber(str, Enum):
     """Congressional chambers."""
 
     HOUSE = "house"
     SENATE = "senate"
+
+
+ChamberLiteral = Literal["house", "senate"]
 
 
 class LawType(str, Enum):
@@ -50,6 +66,9 @@ class LawType(str, Enum):
     PRIV = "priv"
 
 
+LawTypeLiteral = Literal["pub", "priv"]
+
+
 class ReportType(str, Enum):
     """Committee report type codes.
 
@@ -61,6 +80,9 @@ class ReportType(str, Enum):
     HRPT = "hrpt"
     SRPT = "srpt"
     ERPT = "erpt"
+
+
+ReportTypeLiteral = Literal["hrpt", "srpt", "erpt"]
 
 
 class HouseCommunicationType(str, Enum):
@@ -78,6 +100,9 @@ class HouseCommunicationType(str, Enum):
     ML = "ml"
 
 
+HouseCommunicationTypeLiteral = Literal["ec", "pm", "pt", "ml"]
+
+
 class SenateCommunicationType(str, Enum):
     """Senate communication type codes.
 
@@ -89,3 +114,6 @@ class SenateCommunicationType(str, Enum):
     EC = "ec"
     POM = "pom"
     PM = "pm"
+
+
+SenateCommunicationTypeLiteral = Literal["ec", "pom", "pm"]


### PR DESCRIPTION
## Summary

- Replaces Pydantic `str, Enum` types with `Literal` types in all tool parameter signatures, eliminating `$ref`/`$defs` indirection in JSON schemas that caused LLM clients to send wrong types (e.g. boolean `True` instead of string `"hamdt"`)
- Adds boolean-specific error handling in the validation middleware with clear "this requires a STRING, not a boolean" messaging
- Adds 10 new tests covering boolean input rejection and schema flatness verification for all 7 enum types

## Test plan

- [x] All 31 sync tests pass (`pytest tests/ -k "not Middleware and not Pagination and not integration"`)
- [x] Schema flatness verified: no `$ref`/`$defs` in tool schemas, inline `type: "string"` + `enum: [...]`
- [x] Boolean middleware error messages verified for amendment_type, bill_type, and chamber
- [ ] Manual: deploy and verify Claude can call `get_amendment` with `amendment_type: "hamdt"` without boolean confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)