### PR TITLE
Add search_summaries tool for keyword search on bill summaries (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server providing comprehensive access to the offi
 
 ## Features
 
-- **84 Tools** covering all Congress.gov API endpoints
+- **85 Tools** covering all Congress.gov API endpoints
 - **8 Resources** for reference data and direct access
 - Full async support for efficient concurrent requests
 - Auto-pagination for large result sets
@@ -186,6 +186,20 @@ list_treaties(congress=118)
 
 # Get treaty details
 get_treaty(congress=118, treaty_number=3)
+```
+
+### Summaries
+
+```
+# Search bill summaries by keyword (handles pagination internally)
+search_summaries(congress=118, query="artificial intelligence", bill_type="hr",
+                 from_date="2024-01-01", to_date="2024-12-31", max_matches=10)
+
+# List recent summaries
+list_summaries(limit=10)
+
+# List summaries for a specific Congress
+list_summaries_by_congress(congress=118, from_date="2024-01-01", to_date="2024-12-31")
 ```
 
 ### Votes

--- a/src/congress_mcp/tools/summaries.py
+++ b/src/congress_mcp/tools/summaries.py
@@ -1,5 +1,6 @@
 """Summary tools for Congress.gov API."""
 
+import re
 from typing import Annotated, Any
 
 from pydantic import Field
@@ -13,6 +14,24 @@ try:
     from fastmcp import FastMCP
 except ImportError:
     FastMCP = Any  # type: ignore[misc, assignment]
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_HTML_ENTITIES = {
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&quot;": '"',
+    "&#39;": "'",
+    "&nbsp;": " ",
+}
+
+
+def _strip_html(text: str) -> str:
+    """Remove HTML tags and decode common entities from summary text."""
+    clean = _HTML_TAG_RE.sub("", text)
+    for entity, char in _HTML_ENTITIES.items():
+        clean = clean.replace(entity, char)
+    return clean
 
 
 def register_summary_tools(mcp: "FastMCP", config: Config) -> None:
@@ -133,3 +152,98 @@ def register_summary_tools(mcp: "FastMCP", config: Config) -> None:
                 limit=limit,
                 offset=offset,
             )
+
+    @mcp.tool(annotations=READONLY_ANNOTATIONS)
+    async def search_summaries(
+        congress: Annotated[int, Field(description="Congress number (e.g., 118)", ge=1, le=200)],
+        query: Annotated[
+            str,
+            Field(
+                description="Keyword or phrase to search for in summary text (case-insensitive)",
+                min_length=2,
+            ),
+        ],
+        bill_type: Annotated[
+            BillTypeLiteral | None,
+            Field(
+                description="Optional bill type filter: hr, s, hjres, sjres, hconres, sconres, hres, sres"
+            ),
+        ] = None,
+        from_date: Annotated[
+            str | None, Field(description="Filter by update date start (YYYY-MM-DD)")
+        ] = None,
+        to_date: Annotated[
+            str | None, Field(description="Filter by update date end (YYYY-MM-DD)")
+        ] = None,
+        max_matches: Annotated[
+            int,
+            Field(description="Maximum matching summaries to return (default 50)", ge=1, le=500),
+        ] = 50,
+    ) -> dict[str, Any]:
+        """Search bill summaries by keyword with automatic pagination.
+
+        Fetches all summaries for the specified Congress and filters by keyword
+        against the summary text. Handles pagination internally so the caller
+        does not need to page through results manually.
+
+        The search is case-insensitive and matches against the plain text
+        content of each summary (HTML tags are stripped before matching).
+
+        Tip: Provide bill_type to narrow results and speed up the search.
+        For past Congresses, from_date/to_date are required for the API
+        to return results.
+        """
+        async with CongressClient(config) as client:
+            if bill_type:
+                endpoint = f"/summaries/{congress}/{bill_type}"
+            else:
+                endpoint = f"/summaries/{congress}"
+
+            params: dict[str, Any] = {}
+            if from_date:
+                params["fromDateTime"] = f"{from_date}T00:00:00Z"
+            if to_date:
+                params["toDateTime"] = f"{to_date}T23:59:59Z"
+
+            query_lower = query.lower()
+            matches: list[dict[str, Any]] = []
+            total_searched = 0
+            offset = 0
+            batch_size = config.max_limit
+
+            while True:
+                response = await client.get(
+                    endpoint,
+                    params=params,
+                    limit=batch_size,
+                    offset=offset,
+                )
+
+                summaries = response.get("summaries", [])
+                total_searched += len(summaries)
+
+                for summary in summaries:
+                    text = summary.get("text", "")
+                    plain_text = _strip_html(text)
+                    if query_lower in plain_text.lower():
+                        matches.append(summary)
+                        if len(matches) >= max_matches:
+                            break
+
+                if len(matches) >= max_matches:
+                    break
+
+                pagination = response.get("pagination", {})
+                total_count = pagination.get("count", 0)
+
+                if offset + batch_size >= total_count or not summaries:
+                    break
+
+                offset += batch_size
+
+            return {
+                "matches": matches,
+                "match_count": len(matches),
+                "total_summaries_searched": total_searched,
+                "query": query,
+            }

--- a/tests/test_tools/test_summaries.py
+++ b/tests/test_tools/test_summaries.py
@@ -164,6 +164,8 @@ def test_strip_html_handles_empty():
 
 
 # --- search_summaries tests ---
+# Use 118th Congress with date filters and bill_type="hr" for reliable results.
+# The API only returns a small window without dates, so date filters are essential.
 
 
 @needs_api_key
@@ -172,8 +174,11 @@ async def test_search_summaries_finds_matches(client: Client):
     result = await client.call_tool(
         "search_summaries",
         {
-            "congress": CURRENT_CONGRESS,
+            "congress": CONGRESS,
             "query": "artificial intelligence",
+            "bill_type": "hr",
+            "from_date": "2024-01-01",
+            "to_date": "2024-12-31",
             "max_matches": 5,
         },
     )
@@ -189,7 +194,11 @@ async def test_search_summaries_finds_matches(client: Client):
 
 @needs_api_key
 async def test_search_summaries_no_matches(client: Client):
-    """search_summaries returns empty results for a nonsense keyword."""
+    """search_summaries returns empty results for a nonsense keyword.
+
+    Uses current congress without dates (small result set) to avoid
+    long pagination when no matches trigger early termination.
+    """
     result = await client.call_tool(
         "search_summaries",
         {
@@ -210,8 +219,11 @@ async def test_search_summaries_case_insensitive(client: Client):
     result = await client.call_tool(
         "search_summaries",
         {
-            "congress": CURRENT_CONGRESS,
+            "congress": CONGRESS,
             "query": "ARTIFICIAL INTELLIGENCE",
+            "bill_type": "hr",
+            "from_date": "2024-01-01",
+            "to_date": "2024-12-31",
             "max_matches": 3,
         },
     )
@@ -221,12 +233,14 @@ async def test_search_summaries_case_insensitive(client: Client):
 
 @needs_api_key
 async def test_search_summaries_without_bill_type(client: Client):
-    """search_summaries works without bill_type filter."""
+    """search_summaries works without bill_type filter (searches all types)."""
     result = await client.call_tool(
         "search_summaries",
         {
-            "congress": CURRENT_CONGRESS,
+            "congress": CONGRESS,
             "query": "artificial intelligence",
+            "from_date": "2024-01-01",
+            "to_date": "2024-12-31",
             "max_matches": 3,
         },
     )
@@ -241,9 +255,11 @@ async def test_search_summaries_max_matches_respected(client: Client):
     result = await client.call_tool(
         "search_summaries",
         {
-            "congress": CURRENT_CONGRESS,
-            "query": "the",
+            "congress": CONGRESS,
+            "query": "health",
             "bill_type": "hr",
+            "from_date": "2024-01-01",
+            "to_date": "2024-12-31",
             "max_matches": 2,
         },
     )
@@ -257,8 +273,11 @@ async def test_search_summaries_includes_bill_info(client: Client):
     result = await client.call_tool(
         "search_summaries",
         {
-            "congress": CURRENT_CONGRESS,
+            "congress": CONGRESS,
             "query": "artificial intelligence",
+            "bill_type": "hr",
+            "from_date": "2024-01-01",
+            "to_date": "2024-12-31",
             "max_matches": 1,
         },
     )

--- a/tests/test_tools/test_summaries.py
+++ b/tests/test_tools/test_summaries.py
@@ -211,6 +211,7 @@ async def test_search_summaries_no_matches(client: Client):
     assert data["match_count"] == 0
     assert data["matches"] == []
     assert data["total_summaries_searched"] > 0
+    assert data["search_complete"] is True
 
 
 @needs_api_key


### PR DESCRIPTION
## Summary
Adds a new `search_summaries` tool that searches bill summaries by keyword with automatic pagination. The Congress.gov API v3 has no server-side text search, so clients previously needed 14+ sequential API calls to find summaries matching a query.

## Changes
- New `search_summaries` tool filters summaries by case-insensitive keyword match on plain text (HTML stripped)
- Optional `bill_type` parameter narrows API results before client-side filtering
- Early termination when `max_matches` (default 50) is reached, avoiding unnecessary API calls
- `_strip_html()` helper removes HTML markup and decodes entities for clean text matching
- Comprehensive unit tests for `_strip_html` and live API tests with AI-related queries

Fixes #17

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>