### PR TITLE
Add retry/backoff on 429 rate limits (issue #18)

### DIFF
--- a/src/congress_mcp/config.py
+++ b/src/congress_mcp/config.py
@@ -13,6 +13,8 @@ class Config:
     default_limit: int = 20
     max_limit: int = 250
     timeout: float = 30.0
+    max_retries: int = 3
+    retry_base_delay: float = 1.0
 
     @classmethod
     def from_env(cls) -> "Config":
@@ -26,6 +28,8 @@ class Config:
             CONGRESS_DEFAULT_LIMIT: Default pagination limit (default: 20)
             CONGRESS_MAX_LIMIT: Maximum pagination limit (default: 250)
             CONGRESS_TIMEOUT: Request timeout in seconds (default: 30.0)
+            CONGRESS_MAX_RETRIES: Max retry attempts on 429 rate limit (default: 3)
+            CONGRESS_RETRY_BASE_DELAY: Base delay in seconds for exponential backoff (default: 1.0)
 
         Raises:
             ValueError: If CONGRESS_API_KEY is not set.
@@ -43,4 +47,6 @@ class Config:
             default_limit=int(os.environ.get("CONGRESS_DEFAULT_LIMIT", str(cls.default_limit))),
             max_limit=int(os.environ.get("CONGRESS_MAX_LIMIT", str(cls.max_limit))),
             timeout=float(os.environ.get("CONGRESS_TIMEOUT", str(cls.timeout))),
+            max_retries=int(os.environ.get("CONGRESS_MAX_RETRIES", str(cls.max_retries))),
+            retry_base_delay=float(os.environ.get("CONGRESS_RETRY_BASE_DELAY", str(cls.retry_base_delay))),
         )


### PR DESCRIPTION
## Summary

Add exponential backoff retry logic to `CongressClient.get()` when the API returns 429 rate limit responses. The HTTP client now retries up to 3 times (configurable) with exponential backoff (1s, 2s, 4s) before raising `RateLimitError`. Respects the `Retry-After` header if present.

## Changes

- **config.py**: Add `max_retries` (default 3) and `retry_base_delay` (default 1.0s) with env var support
- **client.py**: Implement retry loop in `get()` method with exponential backoff on 429
- **test_client.py**: Update existing 429 tests, add 4 new retry-specific tests

## Test plan

- [x] All 116 tests pass, including 21 client tests
- [x] Retry succeeds after transient 429 responses
- [x] Respects Retry-After header if present
- [x] No retry on non-429 errors (404, 401, 500, etc.)
- [x] Zero-retries config works (immediate failure)